### PR TITLE
Add module docstrings everywhere

### DIFF
--- a/conda_declarative/constants.py
+++ b/conda_declarative/constants.py
@@ -1,2 +1,4 @@
+"""Constants for conda-declarative."""
+
 CONDA_HISTORY_D = "conda-meta/history.d"
 CONDA_MANIFEST_FILE = "conda-meta/environment.toml"

--- a/conda_declarative/exceptions.py
+++ b/conda_declarative/exceptions.py
@@ -1,3 +1,5 @@
+"""Exception classes for conda-declarative."""
+
 from conda.exceptions import CondaExitZero
 
 

--- a/conda_declarative/plugin.py
+++ b/conda_declarative/plugin.py
@@ -1,3 +1,13 @@
+"""Plugin implementations for conda-declarative functionality.
+
+Includes:
+- Conda subcommand hooks for adding the `conda edit` and `conda apply` commands
+- A post-transaction action hook for updating `conda.toml` when the user installs,
+  updates, or removes packages
+- A reporter backend hook for redirecting progress info from conda to the TUI
+- An environment specifier hook for using `conda.toml` to specify conda environments
+"""
+
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/conda_declarative/renderers.py
+++ b/conda_declarative/renderers.py
@@ -1,3 +1,10 @@
+"""Renderers which pass conda progress information to the TUI.
+
+The TuiReporterRenderer instantiates TuiProgressBar and TuiSpinner instances, both
+of which pass their respective status information to the global `conda_declarative.app`
+singleton instance. The app in turn updates the UI.
+"""
+
 from __future__ import annotations  # noqa: I001
 
 from uuid import uuid4

--- a/conda_declarative/spec.py
+++ b/conda_declarative/spec.py
@@ -1,3 +1,11 @@
+"""Implementation of the TOML specification for conda environments.
+
+The main object of interest is the `TomlSpec` class, which implements conda's
+environment specification. It does this with the help of the TomlSingleEnvironment
+pydantic model, which it uses for serializing and deserializing environment and
+environment configuration data. See the docstring for `TomlSpec` for more information.
+"""
+
 from __future__ import annotations
 
 import string

--- a/conda_declarative/util.py
+++ b/conda_declarative/util.py
@@ -1,3 +1,5 @@
+"""Assorted utilities for conda-declarative."""
+
 from __future__ import annotations
 
 from argparse import Namespace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ ignore = [
     "ANN201", # Missing return type annotation for public function (makes no sense for NoneType return types...)
     "ANN204", # Missing return type annotation for special method
     "B905", # zip() without an explicit strict=; incompatible with python<3.12
-    "D100", # Missing docstring in public module
     "D104", # Missing docstring in public package
     "D105", # Missing docstring in magic method
     "D107", # Missing docstring in __init__
@@ -193,6 +192,8 @@ ignore = [
 "__init__.py" = ["F401"]
 "test_*.py" = ["ANN001"]
 "conftest.py" = ["ANN001"]
+"docs/*.py" = ["D100"]
+"tests/*.py" = ["D100"]
 
 [dependency-groups]
 test = ["packaging"]


### PR DESCRIPTION
This PR adds module docstrings everywhere, and modifies the pre-commit config to treat missing module docstrings as lint violations (except in `tests/` and `docs/`). Closes #28.